### PR TITLE
Update tab appearance after page setup

### DIFF
--- a/Sources/ACTabScrollView.swift
+++ b/Sources/ACTabScrollView.swift
@@ -59,7 +59,7 @@ public class ACTabScrollView: UIView, UIScrollViewDelegate {
     }
     
     private var isStarted = false
-    private var pageIndex: Int!
+    private var pageIndex = 0
     private var prevPageIndex: Int?
     
     private var isWaitingForPageChangedCallback = false
@@ -381,6 +381,8 @@ public class ACTabScrollView: UIView, UIScrollViewDelegate {
                     cachedPageTabs[i] = tabView
                 }
             }
+
+            updateTabAppearance(animated: false)
             
             let tabSectionHeight = self.tabSectionHeight >= 0 ? self.tabSectionHeight : maxTabViewHeight
             let contentSectionHeight = self.frame.size.height - tabSectionHeight


### PR DESCRIPTION
`updateTabAppearance` is now called immediately after tabs are initialized. This fixes an issue where tabs flashed black on initial display. It should also fix a race condition where tabs sometimes turn entirely black until the user scrolls, which I think was due to `reloadData` being called (which then calls `setupPages`).